### PR TITLE
Moved metrics to server. Fixed re-bind

### DIFF
--- a/lib/processors.js
+++ b/lib/processors.js
@@ -6,7 +6,6 @@ var targets = path.resolve(__dirname + '/../targets');
 var Promise = require('rsvp').Promise;
 var EventEmitter = require('events').EventEmitter;
 var log = require('./log');
-var metrics = require('./metrics');
 var available = [];
 
 // make our processors object eventy
@@ -44,7 +43,7 @@ function loadTargets() {
         }
       });
 
-      log('Processors available: ' + available.sort().join(' '));
+      // log('Processors available: ' + available.sort().join(' '));
       resolve([].slice.call(available));
     });
   });
@@ -56,28 +55,10 @@ function has(language) {
 
 function run(event) {
   var lang = event.language;
-  // send metric increment for event.language
-  metrics.increment(lang + '.run');
-  // start timer for metric
-  var timer = metrics.createTimer(lang + '.timer');
   return new Promise(function (resolve, reject) {
     var module = require(path.join(targets, lang));
     // FIXME ensure the url and revision are legit
     module(resolve, reject, {language: lang, source: event.source, file: event.url + '.' + event.revision});
-  }).then(function (data) {
-    // end timer
-    timer.stop();
-    if (data.errors === null) {
-      metrics.increment(lang + '.run.successfull');
-    } else {
-      metrics.increment(lang + '.run.error');
-    }
-    return data;
-  }, function (error) {
-    // end timer
-    timer.stop();
-    metrics.increment(lang + '.error');
-    throw error;
   });
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,6 +12,7 @@ var axon = require('axon');
 var Promise = require('rsvp').Promise; // jshint ignore:line
 var processors = require('./processors');
 var log = require('./log');
+var metrics = require('./metrics');
 var psTree = require('ps-tree');
 
 var port = process.env.PORT || 5555;
@@ -31,7 +32,7 @@ function start() {
   if (local) {
     // this is a fudge to allow tests to work
     responder.bind(port, host);
-    responder.on('bind', function () {
+    responder.once('bind', function () {
       log('Ready on tcp://' + host + ':' + port + '...');
       server.stop = responder.close.bind(responder);
       bind();
@@ -40,17 +41,26 @@ function start() {
     });
   } else {
     // production based, connect to the remote port
-    log('connecting to pull from host: ' + host + ':' + port);
+    log('Trying to connect to pull from tcp://' + host + ':' + port + '...');
     responder.connect(port, host);
-    responder.on('connect', function () {
-      log('Ready pulling on tcp://' + host + ':' + port + '...');
+    responder.once('connect', function () {
       server.stop = responder.close.bind(responder);
       bind();
+    }).on('connect', function () {
+      log('Ready pulling on tcp://' + host + ':' + port + '...');
     }).on('bind', function () {
       log('new connection');
     });
   }
-  responder.on('socket error', log).on('error', log).on('close', function () {
+
+  var lastSocketError = null;
+
+  responder.on('socket error', function (error) {
+    if (!lastSocketError || lastSocketError.message !== error.message) {
+      lastSocketError = error;
+      console.error('socket error: ' + error.message);
+    }
+  }).on('error', log).on('close', function () {
     log('closed connection');
   });
 
@@ -58,6 +68,11 @@ function start() {
     responder.on('message', function (req, reply) {
       log('message in for: ' + req.language);
       if (processors.has(req.language)) {
+        // send metric increment for event.language
+        metrics.increment(req.language + '.run');
+        // start timer for metric
+        var metricTimer = metrics.createTimer(req.language + '.timer');
+
         var p = new Promise(function (resolve, reject) {
           var child = fork(__dirname + '/processors');
           var output = '';
@@ -72,6 +87,7 @@ function start() {
                 return p.PID;
               })));
             });
+            metrics.increment(req.language + '.timeout');
             reject({ error: 'timeout', data: null });
           }, 10000);
 
@@ -101,8 +117,16 @@ function start() {
 
         p.then(function (result) {
           reply(result);
+          if (result.errors === null) {
+            metrics.increment(req.language + '.run.successful');
+          } else {
+            metrics.increment(req.language + '.run.error');
+          }
         }).catch(function (error) {
           reply(error);
+          metrics.increment(req.language + '.error');
+        }).then(function () {
+          metricTimer.stop();
         });
       }
     });


### PR DESCRIPTION
Found that if the connection to the pull goes down, when it came back up again, since we do ".on('connect', xyz)" xyz would get re-bound over and over making it duplicate it's work. That's now fixed.
