### PR TITLE
Simplify the if else for local usage

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -39,6 +39,9 @@ function start() {
   connectEvent = connectMethod = local ? 'bind' : 'connect';
   newConnectionEvent = local ? 'connect' : 'bind';
 
+  if (!local) {
+    log('Trying to connect to pull from tcp://' + host + ':' + port + '...');
+  }
   responder[connectMethod](port, host);
   responder.once(connectEvent, function () {
     log('Ready pulling on tcp://' + host + ':' + port + '...');

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,7 +34,6 @@ module.exports = server;
 function start() {
   var local = (host === '0.0.0.0' || host === 'localhost');
   var responder = axon.socket('rep');
-  // responder.bind(port, host);
 
   var connectEvent, connectMethod, newConnectionEvent;
   connectEvent = connectMethod = local ? 'bind' : 'connect';

--- a/lib/server.js
+++ b/lib/server.js
@@ -44,7 +44,7 @@ function start() {
   }
   responder[connectMethod](port, host);
   responder.once(connectEvent, function () {
-    log('Ready pulling on tcp://' + host + ':' + port + '...');
+    log('Ready ' + (local ? '' : 'pulling ') + 'on tcp://' + host + ':' + port + '...');
     server.stop = responder.close.bind(responder);
     bind();
   }).on(newConnectionEvent, function () {

--- a/lib/server.js
+++ b/lib/server.js
@@ -35,29 +35,19 @@ function start() {
   var local = (host === '0.0.0.0' || host === 'localhost');
   var responder = axon.socket('rep');
   // responder.bind(port, host);
-  if (local) {
-    // this is a fudge to allow tests to work
-    responder.bind(port, host);
-    responder.once('bind', function () {
-      log('Ready on tcp://' + host + ':' + port + '...');
-      server.stop = responder.close.bind(responder);
-      bind();
-    }).on('connect', function () {
-      log('new connection');
-    });
-  } else {
-    // production based, connect to the remote port
-    log('Trying to connect to pull from tcp://' + host + ':' + port + '...');
-    responder.connect(port, host);
-    responder.once('connect', function () {
-      server.stop = responder.close.bind(responder);
-      bind();
-    }).on('connect', function () {
-      log('Ready pulling on tcp://' + host + ':' + port + '...');
-    }).on('bind', function () {
-      log('new connection');
-    });
-  }
+
+  var connectEvent, connectMethod, newConnectionEvent;
+  connectEvent = connectMethod = local ? 'bind' : 'connect';
+  newConnectionEvent = local ? 'connect' : 'bind';
+
+  responder[connectMethod](port, host);
+  responder.once(connectEvent, function () {
+    log('Ready pulling on tcp://' + host + ':' + port + '...');
+    server.stop = responder.close.bind(responder);
+    bind();
+  }).on(newConnectionEvent, function () {
+    log('new connection');
+  });
 
   var lastSocketError = null;
 


### PR DESCRIPTION
There was a simple pattern here whereby if we connect using the bind
method then we listen for new connections on 'connect' and listen for
ready on the 'bind' event, these events are switched when using the
connect method.

- [ ] Ready to merge
- [ ] Tested for production