### PR TITLE
Use util.log to add time stamps

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,8 +1,16 @@
+var util = require('util');
+
 var debug = !!process.env.VERBOSE;
 
 var noop = function () {};
 
-var log = debug ? console.log.bind(console) : noop;
-log.error = debug ? console.error.bind(console) : noop;
+var logWithPrefix = function (prefix) {
+  return function (msg) {
+    util.log(prefix + ' ' + msg);
+  };
+};
+
+var log = debug ? logWithPrefix('Log::') : noop;
+log.error = debug ? logWithPrefix('Error::') : noop;
 
 module.exports = log;


### PR DESCRIPTION
Prefixs logs/errors with 'Log::' or 'Error::'
closes #29
