### PR TITLE
Disable warnings in Compass.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -10,3 +10,5 @@ css_dir = "stylesheets"
 sass_dir = "sass"
 images_dir = "images"
 javascripts_dir = "javascripts"
+
+disable_warnings = true

--- a/targets/sass/index.js
+++ b/targets/sass/index.js
@@ -59,7 +59,7 @@ module.exports = function (resolve, reject, data) {
   var sourceFile = path.join('sass', data.file + ext);
 
   fs.writeFile(path.join(output, sourceFile), data.source, function () {
-    var args = ['compile', sourceFile, '--no-line-comments', '--boring'];
+    var args = ['compile', sourceFile, '--no-line-comments', '--boring', '--quiet'];
 
     var compass = spawn('compass', args, {
       cwd: output


### PR DESCRIPTION
Warnings in Compass are printed out in the std error causing pennyworth to throw an error.
Also added quiet param to disable any output in the console when creating/changing files.

Note: this change is in the config.rb so the existing files in the live servers need to be updated.
