### PR TITLE
add babel target

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,18 +14,19 @@
     "6to5": "^3.0.10",
     "LiveScript": "^1.2.0",
     "axon": "~2.0.0",
+    "babel-core": "^5.4.2",
     "body-parser": "~1.0.2",
     "coffee-script": "~1.7.1",
-    "less": "~1.7.5",
-    "stylus": "~0.47.1",
     "express": "~4.1.1",
     "gaze": "~0.6.4",
     "jade": "~1.4.2",
+    "less": "~1.7.5",
     "lynx": "0.0.11",
     "marked": "^0.3.2",
     "myth": "~1.1.0",
     "ps-tree": "~0.0.3",
-    "rsvp": "~3.0.1"
+    "rsvp": "~3.0.1",
+    "stylus": "~0.47.1"
   },
   "devDependencies": {
     "mocha": "~1.18.2",

--- a/targets/babel/index.js
+++ b/targets/babel/index.js
@@ -1,0 +1,25 @@
+'use strict';
+var babel = require('babel-core');
+
+module.exports = function convertbabel(resolve, reject, data) {
+  try {
+    var result = babel.transform(data.source, {
+      stage: 0
+    });
+    resolve({
+      errors: null,
+      result: result.code
+    });
+  } catch (e) {
+    console.log('failed babel');
+    var errors = {
+      line: e.loc.line - 1,
+      ch: e.loc.column,
+      msg: e.message
+    };
+    resolve({
+      errors: [errors],
+      result: null
+    });
+  }
+};

--- a/test/targets/babel/babel.test.js
+++ b/test/targets/babel/babel.test.js
@@ -1,0 +1,55 @@
+/* global describe, it, after, before */
+'use strict';
+
+var fs = require('fs');
+
+var should = require('should');
+
+var axon = require('axon');
+var requester = axon.socket('req');
+
+var server = require('../../../lib/server');
+
+describe('Babel', function () {
+
+  before(function () {
+    server.start();
+    requester.connect('tcp://localhost:5555');
+  });
+
+  it('Should process valid ES6 and pass back the compiled source', function (done) {
+    fs.readFile(__dirname + '/sample.js', function (error, file) {
+      requester.send({
+        language: 'es6',
+        source: file.toString()
+      }, function (res) {
+        (res.error === null).should.be.true;
+        (res.output.errors === null).should.be.true;
+        res.output.result.should.exist;
+        done();
+      });
+    });
+  });
+
+  it('Should process invalid ES6 and give back an error', function (done) {
+    fs.readFile(__dirname + '/broken.js', function (error, file) {
+      requester.send({
+        language: 'es6',
+        source: file.toString()
+      }, function (res) {
+        (res.error === null).should.be.true;
+        (res.output.result === null).should.be.true;
+        res.output.errors.should.exist;
+        done();
+      });
+    });
+  });
+
+  after(function () {
+    requester.close();
+    server.stop();
+  });
+
+});
+
+

--- a/test/targets/babel/broken.js
+++ b/test/targets/babel/broken.js
@@ -1,1 +1,1 @@
-const unique = (array) => [...Set(array)
+const unique = array => [...Set(array)

--- a/test/targets/babel/broken.js
+++ b/test/targets/babel/broken.js
@@ -1,0 +1,1 @@
+const unique = (array) => [...Set(array)

--- a/test/targets/babel/sample.js
+++ b/test/targets/babel/sample.js
@@ -1,0 +1,1 @@
+const unique = (array) => [...Set(array)]

--- a/test/targets/babel/sample.js
+++ b/test/targets/babel/sample.js
@@ -1,1 +1,1 @@
-const unique = (array) => [...Set(array)]
+const unique = array => [...Set(array)]


### PR DESCRIPTION
This pull request is related to https://github.com/jsbin/jsbin/pull/2368. I couldn’t get the tests to pass, but multiple were failing so maybe this was due to my local setup.

I wasn’t sure if I should just require babel inside of to5.js and leave everything as is or add babel as a new target. I went with the latter for now.

Let me know if something needs to be changed. :)